### PR TITLE
savetobinary io module, issue #3

### DIFF
--- a/peakinvestigator/io/__init__.py
+++ b/peakinvestigator/io/__init__.py
@@ -1,0 +1,8 @@
+## -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, Veritomyx, Inc.
+#
+# This file is part of the Python SDK for PeakInvestigator
+# (http://veritomyx.com) and is distributed under the terms
+# of the BSD 3-Clause license.
+from .binary import save_binary

--- a/peakinvestigator/io/binary.py
+++ b/peakinvestigator/io/binary.py
@@ -1,0 +1,27 @@
+## -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, Veritomyx, Inc.
+#
+# This file is part of the Python SDK for PeakInvestigator
+# (http://veritomyx.com) and is distributed under the terms
+# of the BSD 3-Clause license.
+import zlib
+import struct
+import six
+
+def save_binary(headers,data_points,handle):
+    for item in headers:
+        handle.write(six.b("# %s" % item))
+    handle.write(six.b('$'))
+    compress = zlib.compressobj()
+    handle.write(compress.compress(struct.pack('>q', len(data_points))))
+    for i, j in data_points:
+        mass = struct.pack('>d', i)
+        height = struct.pack('>d', j)
+        compressed_data = compress.compress(mass)
+        handle.write(compressed_data)
+        compressed_data = compress.compress(height)
+        handle.write(compressed_data)
+    compressed_data = compress.flush()
+    handle.write(compressed_data)
+    handle.write(six.b('\n'))

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -1,0 +1,84 @@
+## -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, Veritomyx, Inc.
+#
+# This file is part of the Python SDK for PeakInvestigator
+# (http://veritomyx.com) and is distributed under the terms
+# of the BSD 3-Clause license.
+
+import unittest
+
+from context import peakinvestigator
+
+from peakinvestigator.io import save_binary
+
+import tempfile, os, six, filecmp
+
+class TestBinary(unittest.TestCase):
+
+    def setUp(self):
+        self.testempty = ['$x\x9cc`\x80\x00\x00\x00\x08\x00\x01\n']
+        self.testheader = [
+            '# This is a header\n# it should contain meta data\n# There is no limit to number of lines, and is optional.\n$x\x9cc`\x80\x00\x00\x00\x08\x00\x01\n']
+
+        self.testexample = [
+            '# This is a header\n# it should contain meta data\n# There is no limit to number of lines, and is optional.\n$x\x9cc`\x00\x03f\x87\xc9^`\x86C\xc0\x8f\xaf\x87\xfac4\x81|\xdb\x82\xc5\xd7\xb9\x1c\x82w\xce\x04\x82Y@\xbe\xcb\xec\xa5\x8fC\x1c\xc2\x1c\xc0\xea\x00\xbb\xdc\x11\xba\n']
+
+    def test_empty(self):
+        fd, filename = tempfile.mkstemp()
+        fd2, filename2 = tempfile.mkstemp()
+        headers = []
+        data_points = []
+        with open(filename, 'wb') as file:
+            save_binary(headers, data_points, handle=file)
+
+        with open(filename, 'rb') as f:
+            buffer = f.read()
+        with open(filename2, 'wb') as file:
+            file.write(six.b(self.testempty[0]))
+        test = filecmp.cmp(filename, filename2, shallow=False)
+        self.assertEqual(True, test)
+        os.close(fd)
+        os.remove(filename)
+        os.close(fd2)
+        os.remove(filename2)
+
+    def test_header(self):
+        fd, filename = tempfile.mkstemp()
+        fd2, filename2 = tempfile.mkstemp()
+        headers = ['This is a header\n','it should contain meta data\n','There is no limit to number of lines, and is optional.\n']
+        data_points = []
+        with open(filename, 'wb') as file:
+            save_binary(headers, data_points, handle=file)
+
+        with open(filename, 'rb') as f:
+            buffer = f.read()
+        with open(filename2, 'wb') as file:
+            file.write(six.b(self.testheader[0]))
+        test = filecmp.cmp(filename, filename2, shallow=False)
+        self.assertEqual(True, test)
+        os.close(fd)
+        os.remove(filename)
+        os.close(fd2)
+        os.remove(filename2)
+
+    def test_full(self):
+        fd, filename = tempfile.mkstemp()
+        fd2, filename2 = tempfile.mkstemp()
+        headers = ['This is a header\n','it should contain meta data\n','There is no limit to number of lines, and is optional.\n']
+        data_points = [[1234.5,67.89],[1234.56,78.9],[1234.567,89.0]]
+        with open(filename, 'wb') as file:
+            save_binary(headers, data_points, handle=file)
+        with open(filename, 'rb') as f:
+            buffer = f.read()
+        with open(filename2, 'wb') as file:
+            file.write(six.b(self.testexample[0]))
+        test = filecmp.cmp(filename, filename2, shallow=False)
+        self.assertEqual(True, test)
+        os.close(fd)
+        os.remove(filename)
+        os.close(fd2)
+        os.remove(filename2)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -31,9 +31,6 @@ class TestBinary(unittest.TestCase):
         data_points = []
         with open(filename, 'wb') as file:
             save_binary(headers, data_points, handle=file)
-
-        with open(filename, 'rb') as f:
-            buffer = f.read()
         with open(filename2, 'wb') as file:
             file.write(six.b(self.testempty[0]))
         test = filecmp.cmp(filename, filename2, shallow=False)
@@ -50,9 +47,6 @@ class TestBinary(unittest.TestCase):
         data_points = []
         with open(filename, 'wb') as file:
             save_binary(headers, data_points, handle=file)
-
-        with open(filename, 'rb') as f:
-            buffer = f.read()
         with open(filename2, 'wb') as file:
             file.write(six.b(self.testheader[0]))
         test = filecmp.cmp(filename, filename2, shallow=False)
@@ -69,8 +63,6 @@ class TestBinary(unittest.TestCase):
         data_points = [[1234.5,67.89],[1234.56,78.9],[1234.567,89.0]]
         with open(filename, 'wb') as file:
             save_binary(headers, data_points, handle=file)
-        with open(filename, 'rb') as f:
-            buffer = f.read()
         with open(filename2, 'wb') as file:
             file.write(six.b(self.testexample[0]))
         test = filecmp.cmp(filename, filename2, shallow=False)

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -12,65 +12,53 @@ from context import peakinvestigator
 
 from peakinvestigator.io import save_binary
 
-import tempfile, os, six, filecmp
+import tempfile, six
 
 class TestBinary(unittest.TestCase):
 
     def setUp(self):
-        self.testempty = ['$x\x9cc`\x80\x00\x00\x00\x08\x00\x01\n']
-        self.testheader = [
-            '# This is a header\n# it should contain meta data\n# There is no limit to number of lines, and is optional.\n$x\x9cc`\x80\x00\x00\x00\x08\x00\x01\n']
-
-        self.testexample = [
-            '# This is a header\n# it should contain meta data\n# There is no limit to number of lines, and is optional.\n$x\x9cc`\x00\x03f\x87\xc9^`\x86C\xc0\x8f\xaf\x87\xfac4\x81|\xdb\x82\xc5\xd7\xb9\x1c\x82w\xce\x04\x82Y@\xbe\xcb\xec\xa5\x8fC\x1c\xc2\x1c\xc0\xea\x00\xbb\xdc\x11\xba\n']
+        self.testempty = '$x\x9cc`\x80\x00\x00\x00\x08\x00\x01\n'
+        self.testheader = '# This is a header\n# it should contain meta data\n# There is no limit to number of lines, and is optional.\n$x\x9cc`\x80\x00\x00\x00\x08\x00\x01\n'
+        self.testfull = '# This is a header\n# it should contain meta data\n# There is no limit to number of lines, and is optional.\n$x\x9cc`\x00\x03f\x87\xc9^`\x86C\xc0\x8f\xaf\x87\xfac4\x81|\xdb\x82\xc5\xd7\xb9\x1c\x82w\xce\x04\x82Y@\xbe\xcb\xec\xa5\x8fC\x1c\xc2\x1c\xc0\xea\x00\xbb\xdc\x11\xba\n'
 
     def test_empty(self):
-        fd, filename = tempfile.mkstemp()
-        fd2, filename2 = tempfile.mkstemp()
         headers = []
         data_points = []
-        with open(filename, 'wb') as file:
-            save_binary(headers, data_points, handle=file)
-        with open(filename2, 'wb') as file:
-            file.write(six.b(self.testempty[0]))
-        test = filecmp.cmp(filename, filename2, shallow=False)
-        self.assertEqual(True, test)
-        os.close(fd)
-        os.remove(filename)
-        os.close(fd2)
-        os.remove(filename2)
+        with tempfile.TemporaryFile() as temp:
+            save_binary(headers, data_points, handle=temp)
+            temp.seek(0)
+            f1 = temp.read()
+        with tempfile.TemporaryFile() as temp2:
+            temp2.write(six.b(self.testempty))
+            temp2.seek(0)
+            f2 = temp2.read()
+        self.assertEqual(f1, f2)
 
     def test_header(self):
-        fd, filename = tempfile.mkstemp()
-        fd2, filename2 = tempfile.mkstemp()
         headers = ['This is a header\n','it should contain meta data\n','There is no limit to number of lines, and is optional.\n']
         data_points = []
-        with open(filename, 'wb') as file:
-            save_binary(headers, data_points, handle=file)
-        with open(filename2, 'wb') as file:
-            file.write(six.b(self.testheader[0]))
-        test = filecmp.cmp(filename, filename2, shallow=False)
-        self.assertEqual(True, test)
-        os.close(fd)
-        os.remove(filename)
-        os.close(fd2)
-        os.remove(filename2)
+        with tempfile.TemporaryFile() as temp:
+            save_binary(headers, data_points, handle=temp)
+            temp.seek(0)
+            f1 = temp.read()
+        with tempfile.TemporaryFile() as temp2:
+            temp2.write(six.b(self.testheader))
+            temp2.seek(0)
+            f2 = temp2.read()
+        self.assertEqual(f1, f2)
 
     def test_full(self):
-        fd, filename = tempfile.mkstemp()
-        fd2, filename2 = tempfile.mkstemp()
         headers = ['This is a header\n','it should contain meta data\n','There is no limit to number of lines, and is optional.\n']
         data_points = [[1234.5,67.89],[1234.56,78.9],[1234.567,89.0]]
-        with open(filename, 'wb') as file:
-            save_binary(headers, data_points, handle=file)
-        with open(filename2, 'wb') as file:
-            file.write(six.b(self.testexample[0]))
-        test = filecmp.cmp(filename, filename2, shallow=False)
-        self.assertEqual(True, test)
-        os.close(fd)
-        os.remove(filename)
-        os.close(fd2)
-        os.remove(filename2)
+        with tempfile.TemporaryFile() as temp:
+            save_binary(headers, data_points, handle=temp)
+            temp.seek(0)
+            f1 = temp.read()
+        with tempfile.TemporaryFile() as temp2:
+            temp2.write(six.b(self.testfull))
+            temp2.seek(0)
+            f2 = temp2.read()
+        self.assertEqual(f1, f2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/travis/run_travis_tests.sh
+++ b/travis/run_travis_tests.sh
@@ -12,4 +12,6 @@ python -m test_init &&
 python -m test_sftp &&
 python -m test_run &&
 python -m test_status &&
-python -m test_delete 
+python -m test_delete &&
+python -m test_upload &&
+python -m test_binary


### PR DESCRIPTION
Test script below to address issue#3:
```
from peakinvestigator.io import save_binary

headers = ['This is a header\n','it should contain meta data\n','There is no limit to number of lines, and is optional.\n']
data_points = [[1234.5,67.89],[1234.56,78.9],[1234.567,89.0]]
with open('Test.bin', 'wb') as file:
    save_binary(headers, data_points,handle=file)
```